### PR TITLE
Bypass parameter rules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "imdhemy/laravel-purchases",
+    "name": "imdhemy-simpleclick-dustin/laravel-purchases",
     "description": "Laravel receipt validator for Google Play",
     "keywords": [
         "laravel-in-app-purchases",
@@ -7,7 +7,7 @@
         "in_app_purchases",
         "laravel"
     ],
-    "homepage": "https://github.com/imdhemy/laravel-in-app-purchases",
+    "homepage": "https://github.com/DustinSRamirez/laravel-in-app-purchases",
     "license": "MIT",
     "authors": [
         {

--- a/src/Http/Controllers/ServerNotificationController.php
+++ b/src/Http/Controllers/ServerNotificationController.php
@@ -44,8 +44,9 @@ class ServerNotificationController extends Controller
 
     /**
      * @param AppStoreServerNotificationRequest $request
+     * public function apple(AppStoreServerNotificationRequest $request)
      */
-    public function apple(AppStoreServerNotificationRequest $request)
+    public function apple(Request $request) // bypass parameter rules
     {
         $attributes = $request->all();
         $serverNotification = ServerNotification::fromArray($attributes);


### PR DESCRIPTION
AppStoreServerNotificationRequest is not accepting notifications from appstore because of existing rules. 
