### PR TITLE
Fix return type of method getProviderRepresentation in SubscriptionContract.php

### DIFF
--- a/src/Contracts/SubscriptionContract.php
+++ b/src/Contracts/SubscriptionContract.php
@@ -3,7 +3,7 @@
 
 namespace Imdhemy\Purchases\Contracts;
 
-use Imdhemy\AppStore\Receipts\ReceiptResponse;
+use Imdhemy\AppStore\ValueObjects\ReceiptInfo;
 use Imdhemy\GooglePlay\Subscriptions\SubscriptionPurchase;
 use Imdhemy\Purchases\ValueObjects\Time;
 
@@ -34,7 +34,7 @@ interface SubscriptionContract
     public function getUniqueIdentifier(): string;
 
     /**
-     * @return mixed|SubscriptionPurchase|ReceiptResponse
+     * @return mixed|SubscriptionPurchase|ReceiptInfo
      */
     public function getProviderRepresentation();
 }


### PR DESCRIPTION
**What?**

The return type of _getProviderRepresentation_ method is incorrectly defined in _SubscriptionContract.php_.

_AppStoreSubscription.php_ defines variable _receipt_ to be type of _ReceiptInfo_

```
class AppStoreSubscription implements SubscriptionContract
{
    /**
     * @var ReceiptInfo
     */
    private $receipt;

    /**
     * AppStoreSubscription constructor.
     * @param ReceiptInfo $receipt
     */
    public function __construct(ReceiptInfo $receipt)
    {
        $this->receipt = $receipt;
    }
```

_AppStoreSubscription.php_ also implements _SubscriptionContract_ based on which has method _getProviderRepresentation_ that returns _receipt_ of type _ReceiptInfo_
```
public function getProviderRepresentation()
    {
        return $this->receipt;
    }
```

_SubscriptionContract.php_ method _getProviderRepresentation_ returns type of _ReceiptResponse_ instead of _ReceiptInfo_ as defined in _AppStoreSubscription.php_ .
```
/**
     * @return mixed|SubscriptionPurchase|ReceiptResponse
     */
    public function getProviderRepresentation();
```

**Why?**

This is a problem when IDE suggests methods from _ReceiptResponse_ contract which are not present at _getProviderRepresentation_ and it causes unnecessary confusion.

**How?**

Change the return type from ReceiptResponse to ReceiptInfo.

**Does your code follow the PSR-2 standard?** _(Yes|No)_.

Answer: Yes

**Does the psalm tool show no errors?** _(Yes|No)_.

Answer: Yes

**Are there unit tests related to this PR?** _(Yes|No)_.

Answer: No
