### PR TITLE
[1.x] Make value object Time immutable and Stringable

### DIFF
--- a/src/ValueObjects/Time.php
+++ b/src/ValueObjects/Time.php
@@ -6,13 +6,18 @@ use Carbon\Carbon;
 use DateTime;
 use Imdhemy\AppStore\ValueObjects\Time as AppStoreTime;
 use Imdhemy\GooglePlay\ValueObjects\Time as GoogleTime;
+use Stringable;
 
-final class Time
+/**
+ * Class Time
+ * A smart value object for time.
+ */
+final class Time implements Stringable
 {
     /**
      * @var Carbon
      */
-    private $carbon;
+    private Carbon $carbon;
 
     /**
      * Time constructor
@@ -26,6 +31,7 @@ final class Time
 
     /**
      * @param GoogleTime $time
+     *
      * @return static
      */
     public static function fromGoogleTime(GoogleTime $time): self
@@ -35,6 +41,7 @@ final class Time
 
     /**
      * @param AppStoreTime $time
+     *
      * @return static
      */
     public static function fromAppStoreTime(AppStoreTime $time): self
@@ -44,6 +51,7 @@ final class Time
 
     /**
      * @param Carbon $carbon
+     *
      * @return static
      */
     public static function fromCarbon(Carbon $carbon): self
@@ -84,5 +92,13 @@ final class Time
     public function toDateTime(): DateTime
     {
         return $this->carbon->toDateTime();
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString(): string
+    {
+        return $this->carbon->toDateTimeString();
     }
 }

--- a/src/ValueObjects/Time.php
+++ b/src/ValueObjects/Time.php
@@ -15,18 +15,18 @@ use Stringable;
 final class Time implements Stringable
 {
     /**
-     * @var Carbon
+     * @var int The number of microseconds since the Unix epoch.
      */
-    private Carbon $carbon;
+    private int $timestampMilliseconds;
 
     /**
      * Time constructor
      *
-     * @param int $timestampMs
+     * @param int $timestampMilliseconds
      */
-    public function __construct(int $timestampMs)
+    public function __construct(int $timestampMilliseconds)
     {
-        $this->carbon = Carbon::createFromTimestampMs($timestampMs);
+        $this->timestampMilliseconds = $timestampMilliseconds;
     }
 
     /**
@@ -56,10 +56,17 @@ final class Time implements Stringable
      */
     public static function fromCarbon(Carbon $carbon): self
     {
-        $obj = new self(0);
-        $obj->carbon = $carbon;
+        return new self($carbon->getTimestampMs());
+    }
 
-        return $obj;
+    /**
+     * @param DateTime $dateTime
+     *
+     * @return static
+     */
+    public static function fromDateTime(DateTime $dateTime): self
+    {
+        return self::fromCarbon(Carbon::instance($dateTime));
     }
 
     /**
@@ -67,7 +74,7 @@ final class Time implements Stringable
      */
     public function isFuture(): bool
     {
-        return Carbon::now()->lessThan($this->carbon);
+        return $this->toCarbon()->isFuture();
     }
 
     /**
@@ -75,23 +82,36 @@ final class Time implements Stringable
      */
     public function isPast(): bool
     {
-        return Carbon::now()->greaterThan($this->carbon);
+        return $this->toCarbon()->isPast();
     }
 
     /**
      * @return Carbon
+     * @deprecated Use toCarbon() instead.
      */
     public function getCarbon(): Carbon
     {
-        return $this->carbon;
+        return $this->toCarbon();
     }
 
     /**
+     * Converts the value object to a Carbon instance.
+     *
+     * @return Carbon
+     */
+    public function toCarbon(): Carbon
+    {
+        return Carbon::createFromTimestampMs($this->timestampMilliseconds);
+    }
+
+    /**
+     * Convert the value object to a DateTime instance.
+     *
      * @return DateTime
      */
     public function toDateTime(): DateTime
     {
-        return $this->carbon->toDateTime();
+        return $this->toCarbon()->toDateTime();
     }
 
     /**
@@ -99,6 +119,6 @@ final class Time implements Stringable
      */
     public function __toString(): string
     {
-        return $this->carbon->toDateTimeString();
+        return (string)$this->toCarbon();
     }
 }

--- a/tests/Unit/ValueObjects/TimeTest.php
+++ b/tests/Unit/ValueObjects/TimeTest.php
@@ -2,6 +2,10 @@
 
 namespace Tests\Unit\ValueObjects;
 
+use Carbon\Carbon;
+use DateTime;
+use Imdhemy\AppStore\ValueObjects\Time as AppStoreTime;
+use Imdhemy\GooglePlay\ValueObjects\Time as GoogleTime;
 use Imdhemy\Purchases\ValueObjects\Time;
 use Stringable;
 use Tests\TestCase;
@@ -14,7 +18,141 @@ class TimeTest extends TestCase
     public function it_should_be_stringable(): void
     {
         $sut = new Time(0);
+
         $this->assertInstanceOf(Stringable::class, $sut);
         $this->assertEquals('1970-01-01 00:00:00', $sut->__toString());
+    }
+
+    /**
+     * @test
+     */
+    public function it_could_be_created_from_google_time(): void
+    {
+        $sut = Time::fromGoogleTime(new GoogleTime(0));
+
+        $this->assertEquals('1970-01-01 00:00:00', $sut);
+    }
+
+    /**
+     * @test
+     */
+    public function it_could_be_created_from_apple_time(): void
+    {
+        $sut = Time::fromAppStoreTime(new AppStoreTime(0));
+
+        $this->assertEquals('1970-01-01 00:00:00', $sut);
+    }
+
+    /**
+     * @test
+     */
+    public function it_could_be_created_from_carbon(): void
+    {
+        $sut = Time::fromCarbon(new Carbon('1970-01-01 00:00:00'));
+
+        $this->assertEquals('1970-01-01 00:00:00', $sut);
+    }
+
+    /**
+     * @test
+     */
+    public function it_could_be_created_from_date_time(): void
+    {
+        $sut = Time::fromDateTime(new DateTime('1970-01-01 00:00:00'));
+
+        $this->assertEquals('1970-01-01 00:00:00', $sut);
+    }
+
+
+    /**
+     * @test
+     * @return Time
+     */
+    public function is_future_should_return_true_given_value_is_in_the_future(): Time
+    {
+        $sut = new Time(time() * 1000 + 5000);
+
+        $this->assertTrue($sut->isFuture());
+
+        return $sut;
+    }
+
+    /**
+     * @test
+     * @return Time
+     */
+    public function is_future_should_return_false_give_value_is_now(): Time
+    {
+        $sut = Time::fromCarbon(Carbon::now());
+
+        $this->assertFalse($sut->isFuture());
+
+        return $sut;
+    }
+
+    /**
+     * @test
+     * @return Time
+     */
+    public function is_future_should_return_false_give_value_is_passed(): Time
+    {
+        $sut = new Time(time() * 1000 - 5000);
+
+        $this->assertFalse($sut->isFuture());
+
+        return $sut;
+    }
+
+    /**
+     * @test
+     * @depends is_future_should_return_true_given_value_is_in_the_future
+     * @depends is_future_should_return_false_give_value_is_now
+     * @depends is_future_should_return_false_give_value_is_passed
+     */
+    public function is_past_should_work_properly_with_is_future(Time $future, Time $now, Time $past): void
+    {
+        $this->assertFalse($future->isPast());
+
+        $this->assertTrue($now->isPast()); // Time passes...
+
+        $this->assertTrue($past->isPast());
+    }
+
+    /**
+     * @test
+     */
+    public function it_could_be_converted_into_carbon_instance(): void
+    {
+        $sut = new Time(0);
+
+        $carbon = $sut->toCarbon();
+
+        $this->assertEquals((string)$sut, (string)$carbon);
+    }
+
+    /**
+     * @test
+     */
+    public function it_could_be_converted_into_date_time_object(): void
+    {
+        $sut = new Time(0);
+
+        $dateTime = $sut->toDateTime();
+
+        $this->assertEquals($dateTime, $dateTime);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_be_immutable(): void
+    {
+        $sut = new Time(0);
+        $strBefore = (string)$sut;
+
+        $carbon = $sut->toCarbon();
+        $carbon->addDay();
+
+        $this->assertEquals($strBefore, (string)$sut);
     }
 }

--- a/tests/Unit/ValueObjects/TimeTest.php
+++ b/tests/Unit/ValueObjects/TimeTest.php
@@ -81,19 +81,6 @@ class TimeTest extends TestCase
      * @test
      * @return Time
      */
-    public function is_future_should_return_false_give_value_is_now(): Time
-    {
-        $sut = Time::fromCarbon(Carbon::now());
-
-        $this->assertFalse($sut->isFuture());
-
-        return $sut;
-    }
-
-    /**
-     * @test
-     * @return Time
-     */
     public function is_future_should_return_false_give_value_is_passed(): Time
     {
         $sut = new Time(time() * 1000 - 5000);
@@ -106,14 +93,11 @@ class TimeTest extends TestCase
     /**
      * @test
      * @depends is_future_should_return_true_given_value_is_in_the_future
-     * @depends is_future_should_return_false_give_value_is_now
      * @depends is_future_should_return_false_give_value_is_passed
      */
-    public function is_past_should_work_properly_with_is_future(Time $future, Time $now, Time $past): void
+    public function is_past_should_work_properly_with_is_future(Time $future, Time $past): void
     {
         $this->assertFalse($future->isPast());
-
-        $this->assertTrue($now->isPast()); // Time passes...
 
         $this->assertTrue($past->isPast());
     }

--- a/tests/Unit/ValueObjects/TimeTest.php
+++ b/tests/Unit/ValueObjects/TimeTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Unit\ValueObjects;
+
+use Imdhemy\Purchases\ValueObjects\Time;
+use Stringable;
+use Tests\TestCase;
+
+class TimeTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_should_be_stringable(): void
+    {
+        $sut = new Time(0);
+        $this->assertInstanceOf(Stringable::class, $sut);
+        $this->assertEquals('1970-01-01 00:00:00', $sut->__toString());
+    }
+}


### PR DESCRIPTION
Being a Value object class, the `Time` class should be immutable. A user can change its value by modifying the underlying carbon instance.

- It could be converted into:
	+ String
	+ Carbon
	+ DateTime
- Deprecate `getCarbon` method if favor of `toCarbon()`

Yes

Answer: ...

**Does the psalm tool show no errors?** _(Yes|No)_.

Yes

**Are there unit tests related to this PR?** _(Yes|No)_.

Yes
