### PR TITLE
[1.x] Retrieve `autoRenewProductId` from App Store server notification

### DIFF
--- a/src/Events/AppStore/DidChangeRenewalPref.php
+++ b/src/Events/AppStore/DidChangeRenewalPref.php
@@ -6,4 +6,11 @@ use Imdhemy\Purchases\Events\PurchaseEvent;
 
 class DidChangeRenewalPref extends PurchaseEvent
 {
+    /**
+     * @return string|null
+     */
+    public function getAutoRenewProductId(): ?string
+    {
+        return $this->serverNotification->getAutoRenewProductId();
+    }
 }

--- a/src/ServerNotifications/AppStoreServerNotification.php
+++ b/src/ServerNotifications/AppStoreServerNotification.php
@@ -75,7 +75,7 @@ class AppStoreServerNotification implements ServerNotificationContract
     public function getAutoRenewStatusChangeDate(): ?Time
     {
         $time = $this->notification->getAutoRenewStatusChangeDate();
-        if (!is_null($time)) {
+        if (! is_null($time)) {
             return Time::fromAppStoreTime($time);
         }
 

--- a/src/ServerNotifications/AppStoreServerNotification.php
+++ b/src/ServerNotifications/AppStoreServerNotification.php
@@ -75,7 +75,7 @@ class AppStoreServerNotification implements ServerNotificationContract
     public function getAutoRenewStatusChangeDate(): ?Time
     {
         $time = $this->notification->getAutoRenewStatusChangeDate();
-        if (! is_null($time)) {
+        if (!is_null($time)) {
             return Time::fromAppStoreTime($time);
         }
 
@@ -88,5 +88,13 @@ class AppStoreServerNotification implements ServerNotificationContract
     public function getBundle(): string
     {
         return (string)$this->notification->getBid();
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getAutoRenewProductId(): ?string
+    {
+        return $this->notification->getAutoRenewProductId();
     }
 }

--- a/tests/ServerNotifications/AppStoreServerNotificationTest.php
+++ b/tests/ServerNotifications/AppStoreServerNotificationTest.php
@@ -75,4 +75,12 @@ class AppStoreServerNotificationTest extends TestCase
     {
         $this->assertNotNull($this->appStoreServerNotification->getBundle());
     }
+
+    /**
+     * @test
+     */
+    public function test_get_auto_renew_product_id()
+    {
+        $this->assertNotNull($this->appStoreServerNotification->getAutoRenewProductId());
+    }
 }


### PR DESCRIPTION
**What?**

Add new property `autoRenewProductId` into AppStoreServerNotification (v1)

**Why?**

When we capture event `DidChangeRenewalPref`, it would be convenient to retrieve new product id downgraded.

**How?**

Add new accessor for `autoRenewProductId` into `AppStoreServerNotification` and `DidChangeRenewalPref` class

**Does your code follow the PSR-12 standard?** _(Yes|No)_.

Yes

**Does the psalm tool show no errors?** _(Yes|No)_.

No

**Are there unit tests related to this PR?** _(Yes|No)_.

Yes
