### PR TITLE
[1.x] Support requesting a test notification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ vendor/
 .php-cs-fixer.cache
 
 laravel/
+
+*.p8

--- a/composer.lock
+++ b/composer.lock
@@ -68,16 +68,16 @@
         },
         {
             "name": "dflydev/dot-access-data",
-            "version": "v3.0.1",
+            "version": "v3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dflydev/dflydev-dot-access-data.git",
-                "reference": "0992cc19268b259a39e86f296da5f0677841f42c"
+                "reference": "f41715465d65213d644d3141a6a93081be5d3549"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dflydev/dflydev-dot-access-data/zipball/0992cc19268b259a39e86f296da5f0677841f42c",
-                "reference": "0992cc19268b259a39e86f296da5f0677841f42c",
+                "url": "https://api.github.com/repos/dflydev/dflydev-dot-access-data/zipball/f41715465d65213d644d3141a6a93081be5d3549",
+                "reference": "f41715465d65213d644d3141a6a93081be5d3549",
                 "shasum": ""
             },
             "require": {
@@ -88,7 +88,7 @@
                 "phpunit/phpunit": "^7.5 || ^8.5 || ^9.3",
                 "scrutinizer/ocular": "1.6.0",
                 "squizlabs/php_codesniffer": "^3.5",
-                "vimeo/psalm": "^3.14"
+                "vimeo/psalm": "^4.0.0"
             },
             "type": "library",
             "extra": {
@@ -137,9 +137,9 @@
             ],
             "support": {
                 "issues": "https://github.com/dflydev/dflydev-dot-access-data/issues",
-                "source": "https://github.com/dflydev/dflydev-dot-access-data/tree/v3.0.1"
+                "source": "https://github.com/dflydev/dflydev-dot-access-data/tree/v3.0.2"
             },
-            "time": "2021-08-13T13:06:58+00:00"
+            "time": "2022-10-27T11:44:00+00:00"
         },
         {
             "name": "doctrine/inflector",
@@ -1426,16 +1426,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "2.3.5",
+            "version": "2.3.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "84d74485fdb7074f4f9dd6f02ab957b1de513257"
+                "reference": "857afc47ce113454bd629037213378ba3219dd40"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/84d74485fdb7074f4f9dd6f02ab957b1de513257",
-                "reference": "84d74485fdb7074f4f9dd6f02ab957b1de513257",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/857afc47ce113454bd629037213378ba3219dd40",
+                "reference": "857afc47ce113454bd629037213378ba3219dd40",
                 "shasum": ""
             },
             "require": {
@@ -1455,7 +1455,7 @@
                 "erusev/parsedown": "^1.0",
                 "ext-json": "*",
                 "github/gfm": "0.29.0",
-                "michelf/php-markdown": "^1.4",
+                "michelf/php-markdown": "^1.4 || ^2.0",
                 "nyholm/psr7": "^1.5",
                 "phpstan/phpstan": "^1.8.2",
                 "phpunit/phpunit": "^9.5.21",
@@ -1528,7 +1528,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-07-29T10:59:45+00:00"
+            "time": "2022-10-30T16:45:38+00:00"
         },
         {
             "name": "league/config",
@@ -3490,16 +3490,16 @@
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v5.4.14",
+            "version": "v5.4.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "e7c7b395c3a61d746919c21e915f51f0039c3f75"
+                "reference": "75bd663ff2db90141bfb733682459d5bbe9e29c3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/e7c7b395c3a61d746919c21e915f51f0039c3f75",
-                "reference": "e7c7b395c3a61d746919c21e915f51f0039c3f75",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/75bd663ff2db90141bfb733682459d5bbe9e29c3",
+                "reference": "75bd663ff2db90141bfb733682459d5bbe9e29c3",
                 "shasum": ""
             },
             "require": {
@@ -3546,7 +3546,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v5.4.14"
+                "source": "https://github.com/symfony/http-foundation/tree/v5.4.15"
             },
             "funding": [
                 {
@@ -3562,20 +3562,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-10-01T21:59:28+00:00"
+            "time": "2022-10-12T09:43:19+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v5.4.14",
+            "version": "v5.4.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "6f77fabc1a37c2dceecc6f78cca44772705dc52f"
+                "reference": "fc63c8c3e1036d424820cc993a4ea163778dc5c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/6f77fabc1a37c2dceecc6f78cca44772705dc52f",
-                "reference": "6f77fabc1a37c2dceecc6f78cca44772705dc52f",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/fc63c8c3e1036d424820cc993a4ea163778dc5c7",
+                "reference": "fc63c8c3e1036d424820cc993a4ea163778dc5c7",
                 "shasum": ""
             },
             "require": {
@@ -3658,7 +3658,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v5.4.14"
+                "source": "https://github.com/symfony/http-kernel/tree/v5.4.15"
             },
             "funding": [
                 {
@@ -3674,7 +3674,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-10-12T07:12:21+00:00"
+            "time": "2022-10-28T17:52:18+00:00"
         },
         {
             "name": "symfony/mime",
@@ -4641,16 +4641,16 @@
         },
         {
             "name": "symfony/routing",
-            "version": "v5.4.11",
+            "version": "v5.4.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "3e01ccd9b2a3a4167ba2b3c53612762300300226"
+                "reference": "5c9b129efe9abce9470e384bf65d8a7e262eee69"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/3e01ccd9b2a3a4167ba2b3c53612762300300226",
-                "reference": "3e01ccd9b2a3a4167ba2b3c53612762300300226",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/5c9b129efe9abce9470e384bf65d8a7e262eee69",
+                "reference": "5c9b129efe9abce9470e384bf65d8a7e262eee69",
                 "shasum": ""
             },
             "require": {
@@ -4711,7 +4711,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v5.4.11"
+                "source": "https://github.com/symfony/routing/tree/v5.4.15"
             },
             "funding": [
                 {
@@ -4727,7 +4727,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-07-20T13:00:38+00:00"
+            "time": "2022-10-13T14:10:41+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -5695,23 +5695,23 @@
         },
         {
             "name": "barryvdh/reflection-docblock",
-            "version": "v2.0.6",
+            "version": "v2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/barryvdh/ReflectionDocBlock.git",
-                "reference": "6b69015d83d3daf9004a71a89f26e27d27ef6a16"
+                "reference": "bf44b757feb8ba1734659029357646466ded673e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/barryvdh/ReflectionDocBlock/zipball/6b69015d83d3daf9004a71a89f26e27d27ef6a16",
-                "reference": "6b69015d83d3daf9004a71a89f26e27d27ef6a16",
+                "url": "https://api.github.com/repos/barryvdh/ReflectionDocBlock/zipball/bf44b757feb8ba1734659029357646466ded673e",
+                "reference": "bf44b757feb8ba1734659029357646466ded673e",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0,<4.5"
+                "phpunit/phpunit": "^8.5.14|^9"
             },
             "suggest": {
                 "dflydev/markdown": "~1.0",
@@ -5741,9 +5741,9 @@
                 }
             ],
             "support": {
-                "source": "https://github.com/barryvdh/ReflectionDocBlock/tree/v2.0.6"
+                "source": "https://github.com/barryvdh/ReflectionDocBlock/tree/v2.1.0"
             },
-            "time": "2018-12-13T10:34:14+00:00"
+            "time": "2022-10-31T15:35:43+00:00"
         },
         {
             "name": "composer/package-versions-deprecated",
@@ -6725,16 +6725,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.12.0",
+            "version": "v3.13.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "eae11d945e2885d86e1c080eec1bb30a2aa27998"
+                "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
+                "reference": "a6232229a8309e8811dc751c28b91cb34b2943e1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/eae11d945e2885d86e1c080eec1bb30a2aa27998",
-                "reference": "eae11d945e2885d86e1c080eec1bb30a2aa27998",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/a6232229a8309e8811dc751c28b91cb34b2943e1",
+                "reference": "a6232229a8309e8811dc751c28b91cb34b2943e1",
                 "shasum": ""
             },
             "require": {
@@ -6758,7 +6758,7 @@
             },
             "require-dev": {
                 "justinrainbow/json-schema": "^5.2",
-                "keradus/cli-executor": "^1.5",
+                "keradus/cli-executor": "^2.0",
                 "mikey179/vfsstream": "^1.6.10",
                 "php-coveralls/php-coveralls": "^2.5.2",
                 "php-cs-fixer/accessible-object": "^1.1",
@@ -6801,8 +6801,8 @@
             ],
             "description": "A tool to automatically fix PHP code style",
             "support": {
-                "issues": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues",
-                "source": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v3.12.0"
+                "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.13.0"
             },
             "funding": [
                 {
@@ -6810,7 +6810,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-10-12T14:20:51+00:00"
+            "time": "2022-10-31T19:28:50+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -7587,16 +7587,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.17",
+            "version": "9.2.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "aa94dc41e8661fe90c7316849907cba3007b10d8"
+                "reference": "12fddc491826940cf9b7e88ad9664cf51f0f6d0a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/aa94dc41e8661fe90c7316849907cba3007b10d8",
-                "reference": "aa94dc41e8661fe90c7316849907cba3007b10d8",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/12fddc491826940cf9b7e88ad9664cf51f0f6d0a",
+                "reference": "12fddc491826940cf9b7e88ad9664cf51f0f6d0a",
                 "shasum": ""
             },
             "require": {
@@ -7652,7 +7652,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.17"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.18"
             },
             "funding": [
                 {
@@ -7660,7 +7660,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-08-30T12:24:04+00:00"
+            "time": "2022-10-27T13:35:33+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -7905,16 +7905,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.25",
+            "version": "9.5.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "3e6f90ca7e3d02025b1d147bd8d4a89fd4ca8a1d"
+                "reference": "851867efcbb6a1b992ec515c71cdcf20d895e9d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3e6f90ca7e3d02025b1d147bd8d4a89fd4ca8a1d",
-                "reference": "3e6f90ca7e3d02025b1d147bd8d4a89fd4ca8a1d",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/851867efcbb6a1b992ec515c71cdcf20d895e9d2",
+                "reference": "851867efcbb6a1b992ec515c71cdcf20d895e9d2",
                 "shasum": ""
             },
             "require": {
@@ -7987,7 +7987,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.25"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.26"
             },
             "funding": [
                 {
@@ -8003,7 +8003,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-09-25T03:44:45+00:00"
+            "time": "2022-10-28T06:00:21+00:00"
         },
         {
             "name": "pimple/pimple",
@@ -8131,12 +8131,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "1d3484a08d3875e28bc2ad66697b0947cd6a2d99"
+                "reference": "6ca121cb3bf9f5d33016bfd4a175b0732cf174c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/1d3484a08d3875e28bc2ad66697b0947cd6a2d99",
-                "reference": "1d3484a08d3875e28bc2ad66697b0947cd6a2d99",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/6ca121cb3bf9f5d33016bfd4a175b0732cf174c4",
+                "reference": "6ca121cb3bf9f5d33016bfd4a175b0732cf174c4",
                 "shasum": ""
             },
             "conflict": {
@@ -8159,6 +8159,7 @@
                 "asymmetricrypt/asymmetricrypt": ">=0,<9.9.99",
                 "awesome-support/awesome-support": "<=6.0.7",
                 "aws/aws-sdk-php": ">=3,<3.2.1",
+                "badaso/core": "<2.6.1",
                 "bagisto/bagisto": "<0.1.5",
                 "barrelstrength/sprout-base-email": "<1.2.7",
                 "barrelstrength/sprout-forms": "<3.9",
@@ -8275,7 +8276,7 @@
                 "gaoming13/wechat-php-sdk": "<=1.10.2",
                 "genix/cms": "<=1.1.11",
                 "getgrav/grav": "<1.7.34",
-                "getkirby/cms": "<3.5.8.1|>=3.6,<3.6.6.1|>=3.7,<3.7.4",
+                "getkirby/cms": "= 3.8.0|<3.5.8.2|>=3.6,<3.6.6.2|>=3.7,<3.7.5.1",
                 "getkirby/panel": "<2.5.14",
                 "getkirby/starterkit": "<=3.7.0.2",
                 "gilacms/gila": "<=1.11.4",
@@ -8314,6 +8315,7 @@
                 "joomla/filter": "<1.4.4|>=2,<2.0.1",
                 "joomla/input": ">=2,<2.0.2",
                 "joomla/session": "<1.3.1",
+                "joyqi/hyper-down": "<=2.4.27",
                 "jsdecena/laracom": "<2.0.9",
                 "jsmitty12/phpwhois": "<5.1",
                 "kazist/phpwhois": "<=4.2.6",
@@ -8382,7 +8384,7 @@
                 "october/cms": "= 1.1.1|= 1.0.471|= 1.0.469|>=1.0.319,<1.0.469",
                 "october/october": ">=1.0.319,<1.0.466|>=2.1,<2.1.12",
                 "october/rain": "<1.0.472|>=1.1,<1.1.2",
-                "october/system": "<2.2.34|>=3,<3.0.66",
+                "october/system": "<1.0.476|>=1.1,<1.1.12|>=2,<2.2.34|>=3,<3.0.66",
                 "onelogin/php-saml": "<2.10.4",
                 "oneup/uploader-bundle": "<1.9.3|>=2,<2.1.5",
                 "open-web-analytics/open-web-analytics": "<1.7.4",
@@ -8390,7 +8392,7 @@
                 "openid/php-openid": "<2.3",
                 "openmage/magento-lts": "<19.4.15|>=20,<20.0.13",
                 "orchid/platform": ">=9,<9.4.4",
-                "oro/commerce": ">=5,<5.0.4",
+                "oro/commerce": ">=4.1,<5.0.6",
                 "oro/crm": ">=1.7,<1.7.4|>=3.1,<4.1.17|>=4.2,<4.2.7",
                 "oro/platform": ">=1.7,<1.7.4|>=3.1,<3.1.29|>=4.1,<4.1.17|>=4.2,<4.2.8",
                 "packbackbooks/lti-1-3-php-library": "<5",
@@ -8409,6 +8411,7 @@
                 "phpmailer/phpmailer": "<6.5",
                 "phpmussel/phpmussel": ">=1,<1.6",
                 "phpmyadmin/phpmyadmin": "<5.1.3",
+                "phpmyfaq/phpmyfaq": "<=3.1.7",
                 "phpoffice/phpexcel": "<1.8",
                 "phpoffice/phpspreadsheet": "<1.16",
                 "phpseclib/phpseclib": "<2.0.31|>=3,<3.0.7",
@@ -8417,7 +8420,7 @@
                 "phpwhois/phpwhois": "<=4.2.5",
                 "phpxmlrpc/extras": "<0.6.1",
                 "pimcore/data-hub": "<1.2.4",
-                "pimcore/pimcore": "<=10.5.6",
+                "pimcore/pimcore": "<10.5.9",
                 "pocketmine/bedrock-protocol": "<8.0.2",
                 "pocketmine/pocketmine-mp": "<4.7.2|>= 4.0.0-BETA5, < 4.4.2",
                 "pressbooks/pressbooks": "<5.18",
@@ -8539,6 +8542,7 @@
                 "thelia/thelia": ">=2.1-beta.1,<2.1.3",
                 "theonedemon/phpwhois": "<=4.2.5",
                 "thinkcmf/thinkcmf": "<=5.1.7",
+                "thorsten/phpmyfaq": "<3.1.8",
                 "tinymce/tinymce": "<5.10",
                 "titon/framework": ">=0,<9.9.99",
                 "topthink/framework": "<=6.0.13",
@@ -8570,7 +8574,7 @@
                 "webcoast/deferred-image-processing": "<1.0.2",
                 "wikimedia/parsoid": "<0.12.2",
                 "willdurand/js-translation-bundle": "<2.1.1",
-                "wintercms/winter": "<1.0.475|>=1.1,<1.1.9",
+                "wintercms/winter": "<1.0.475|>=1.1,<1.1.10|>=1.2,<1.2.1",
                 "woocommerce/woocommerce": "<6.6",
                 "wp-cli/wp-cli": "<2.5",
                 "wp-graphql/wp-graphql": "<0.3.5",
@@ -8651,7 +8655,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-10-13T20:04:41+00:00"
+            "time": "2022-10-31T20:04:42+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/config/liap.php
+++ b/config/liap.php
@@ -82,4 +82,21 @@ return [
              \App\Listeners\GooglePlay\SubscriptionRecovered::class,
          ],*/
     ],
+
+    /*
+     | --------------------------------------------------------------------------
+     | App store JWT configuration
+     | --------------------------------------------------------------------------
+     |
+     | The following configuration is used to generate the JWT token used to
+     | authenticate with the App Store server.
+     */
+    // Your private key ID from App Store Connect (Ex: 2X9R4HXF34)
+    'appstore_private_key_id' => env('APPSTORE_PRIVATE_KEY_ID', ''),
+    // The path to your private key file (Ex: /path/to/SuperSecretKey_ABC123.p8)
+    'appstore_private_key' => env('APPSTORE_PRIVATE_KEY', ''),
+    // Your issuer ID from the Keys page in App Store Connect (Ex: "57246542-96fe-1a63-e053-0824d011072a")
+    'appstore_issuer_id' => env('APPSTORE_ISSUER_ID', ''),
+    // Your app’s bundle ID (Ex: “com.example.testbundleid2021”)
+    'appstore_bundle_id' => env('APPSTORE_BUNDLE_ID', ''),
 ];

--- a/config/liap.php
+++ b/config/liap.php
@@ -92,11 +92,11 @@ return [
      | authenticate with the App Store server.
      */
     // Your private key ID from App Store Connect (Ex: 2X9R4HXF34)
-    'appstore_private_key_id' => env('APPSTORE_PRIVATE_KEY_ID', ''),
+    'appstore_private_key_id' => env('APPSTORE_PRIVATE_KEY_ID'),
     // The path to your private key file (Ex: /path/to/SuperSecretKey_ABC123.p8)
-    'appstore_private_key' => env('APPSTORE_PRIVATE_KEY', ''),
+    'appstore_private_key' => env('APPSTORE_PRIVATE_KEY'),
     // Your issuer ID from the Keys page in App Store Connect (Ex: "57246542-96fe-1a63-e053-0824d011072a")
-    'appstore_issuer_id' => env('APPSTORE_ISSUER_ID', ''),
+    'appstore_issuer_id' => env('APPSTORE_ISSUER_ID'),
     // Your app’s bundle ID (Ex: “com.example.testbundleid2021”)
-    'appstore_bundle_id' => env('APPSTORE_BUNDLE_ID', ''),
+    'appstore_bundle_id' => env('APPSTORE_BUNDLE_ID'),
 ];

--- a/src/Console/RequestTestNotificationCommand.php
+++ b/src/Console/RequestTestNotificationCommand.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Imdhemy\Purchases\Console;
+
+use Illuminate\Console\Command;
+
+/**
+ * This command is used to request a test notification from Apple
+ * It uses the configuration from the config file `liap.php`
+ */
+class RequestTestNotificationCommand extends Command
+{
+    /**
+     * @inheritdoc
+     */
+    protected $signature = 'liap:apple:test-notification';
+
+    /**
+     * @inheritdoc
+     */
+    protected $description = 'Request a test notification from Apple';
+
+    /**
+     * Execute the console command
+     *
+     * @return int
+     */
+    public function handle(): int
+    {
+        return self::SUCCESS;
+    }
+}

--- a/src/Console/RequestTestNotificationCommand.php
+++ b/src/Console/RequestTestNotificationCommand.php
@@ -4,7 +4,12 @@ declare(strict_types=1);
 
 namespace Imdhemy\Purchases\Console;
 
+use GuzzleHttp\Exception\GuzzleException;
 use Illuminate\Console\Command;
+use Imdhemy\Purchases\Services\AppStoreTestNotificationService;
+use Imdhemy\Purchases\Services\AppStoreTestNotificationServiceBuilder as ServiceBuilder;
+use JsonException;
+use RuntimeException;
 
 /**
  * This command is used to request a test notification from Apple
@@ -15,7 +20,7 @@ class RequestTestNotificationCommand extends Command
     /**
      * @inheritdoc
      */
-    protected $signature = 'liap:apple:test-notification';
+    protected $signature = 'liap:apple:test-notification {--s|sandbox}';
 
     /**
      * @inheritdoc
@@ -23,12 +28,111 @@ class RequestTestNotificationCommand extends Command
     protected $description = 'Request a test notification from Apple';
 
     /**
+     * @var ServiceBuilder App Store test notification service builder
+     */
+    private ServiceBuilder $serviceBuilder;
+
+    /**
+     * @param ServiceBuilder $serviceBuilder
+     */
+    public function __construct(ServiceBuilder $serviceBuilder)
+    {
+        parent::__construct();
+
+        $this->serviceBuilder = $serviceBuilder;
+    }
+
+
+    /**
      * Execute the console command
      *
      * @return int
+     * @throws JsonException
      */
     public function handle(): int
     {
-        return self::SUCCESS;
+        try {
+            $response = $this->buildService()->request();
+
+            $content = json_decode($response->getBody()->getContents(), true, 512, JSON_THROW_ON_ERROR);
+            $token = $content['testNotificationToken'];
+
+            $this->info(sprintf("Test notification token: %s", $token));
+
+            return self::SUCCESS;
+        } catch (RuntimeException|GuzzleException $exception) {
+            $this->error($exception->getMessage());
+
+            return self::FAILURE;
+        }
+    }
+
+    /**
+     * Builds the AppStoreTestNotificationService
+     */
+    private function buildService(): AppStoreTestNotificationService
+    {
+        $this->setPrivateKeyId();
+        $this->setPrivateKey();
+        $this->setIssuerId();
+        $this->setBundleId();
+
+        return $this->serviceBuilder->sandbox($this->option('sandbox'))->build();
+    }
+
+    /**
+     * Set the private key ID
+     */
+    private function setPrivateKeyId(): void
+    {
+        $privateKeyId = config('liap.appstore_private_key_id');
+
+        if ($privateKeyId === null) {
+            throw new RuntimeException('The private key ID is not configured');
+        }
+
+        $this->serviceBuilder->privateKeyId($privateKeyId);
+    }
+
+    /**
+     * Sets the private key
+     */
+    private function setPrivateKey(): void
+    {
+        $privateKey = config('liap.appstore_private_key');
+
+        if ($privateKey === null) {
+            throw new RuntimeException('The private key is not configured');
+        }
+
+        $this->serviceBuilder->privateKey(file_get_contents($privateKey));
+    }
+
+    /**
+     * Sets the issuer ID
+     */
+    private function setIssuerId(): void
+    {
+        $issuerId = config('liap.appstore_issuer_id');
+
+        if ($issuerId === null) {
+            throw new RuntimeException('The issuer ID is not configured');
+        }
+
+        $this->serviceBuilder->issuerId($issuerId);
+    }
+
+    /**
+     * Sets the bundle ID
+     */
+    private function setBundleId(): void
+    {
+        $bundleId = config('liap.appstore_bundle_id');
+
+        if ($bundleId === null) {
+            throw new RuntimeException('The bundle ID is not configured');
+        }
+
+        $this->serviceBuilder->bundleId($bundleId);
     }
 }

--- a/src/ServiceProviders/LiapServiceProvider.php
+++ b/src/ServiceProviders/LiapServiceProvider.php
@@ -10,6 +10,7 @@ use Imdhemy\AppStore\Jws\JwsVerifier;
 use Imdhemy\AppStore\Jws\Parser;
 use Imdhemy\Purchases\Console\LiapConfigPublishCommand;
 use Imdhemy\Purchases\Console\LiapUrlCommand;
+use Imdhemy\Purchases\Console\RequestTestNotificationCommand;
 use Imdhemy\Purchases\Console\UrlGenerator;
 use Imdhemy\Purchases\Contracts\UrlGenerator as UrlGeneratorContract;
 use Imdhemy\Purchases\Handlers\HandlerHelpers;
@@ -86,6 +87,7 @@ class LiapServiceProvider extends ServiceProvider
             $this->commands([
                 LiapConfigPublishCommand::class,
                 LiapUrlCommand::class,
+                RequestTestNotificationCommand::class,
             ]);
         }
     }

--- a/src/Services/AppStoreTestNotificationService.php
+++ b/src/Services/AppStoreTestNotificationService.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Imdhemy\Purchases\Services;
+
+use GuzzleHttp\Exception\GuzzleException;
+use Imdhemy\AppStore\ServerNotifications\TestNotificationService;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * This class is used to request a test notification from Apple
+ */
+final class AppStoreTestNotificationService
+{
+    /**
+     * @var TestNotificationService
+     */
+    private TestNotificationService $service;
+
+    /**
+     * @param TestNotificationService $service
+     */
+    public function __construct(TestNotificationService $service)
+    {
+        $this->service = $service;
+    }
+
+    /**
+     * @throws GuzzleException
+     */
+    public function request(): ResponseInterface
+    {
+        return $this->service->request();
+    }
+}

--- a/src/Services/AppStoreTestNotificationServiceBuilder.php
+++ b/src/Services/AppStoreTestNotificationServiceBuilder.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Imdhemy\Purchases\Services;
+
+use GuzzleHttp\Client;
+use Imdhemy\AppStore\ClientFactory;
+use Imdhemy\AppStore\Jws\AppStoreJwsGenerator;
+use Imdhemy\AppStore\Jws\GeneratorConfig;
+use Imdhemy\AppStore\Jws\Issuer;
+use Imdhemy\AppStore\Jws\Key;
+use Imdhemy\AppStore\ServerNotifications\TestNotificationService;
+use Lcobucci\JWT\Signer\Ecdsa\Sha256;
+use Lcobucci\JWT\Signer\Key\InMemory;
+
+/**
+ * This class is used to build AppStoreTestNotificationService
+ */
+class AppStoreTestNotificationServiceBuilder
+{
+    /**
+     * @var bool
+     */
+    protected bool $sandbox = false;
+
+    /**
+     * @var string|null
+     */
+    private ?string $issuerId = null;
+
+    /**
+     * @var string|null
+     */
+    private ?string $bundleId = null;
+
+    /**
+     * @var string|null
+     */
+    private ?string $privateKeyId = null;
+
+    /**
+     * @var string|null
+     */
+    private ?string $privateKey = null;
+
+    /**
+     * Builds a new instance of AppStoreTestNotificationService
+     *
+     * @return AppStoreTestNotificationService
+     */
+    public function build(): AppStoreTestNotificationService
+    {
+        $config = GeneratorConfig::forAppStore(
+            new Issuer(
+                $this->issuerId,
+                $this->bundleId,
+                new Key($this->privateKeyId, InMemory::plainText($this->privateKey)),
+                Sha256::create()
+            ),
+        );
+        $jwsGenerator = new AppStoreJwsGenerator($config);
+
+        $client = $this->createClient();
+
+        $service = new TestNotificationService($client, $jwsGenerator);
+
+        return new AppStoreTestNotificationService($service);
+    }
+
+    /**
+     * @param string|null $issuerId
+     *
+     * @return $this
+     */
+    public function issuerId(?string $issuerId): self
+    {
+        $this->issuerId = $issuerId;
+
+        return $this;
+    }
+
+    /**
+     * @param string|null $bundleId
+     *
+     * @return $this
+     */
+    public function bundleId(?string $bundleId): self
+    {
+        $this->bundleId = $bundleId;
+
+        return $this;
+    }
+
+    /**
+     * @param string|null $privateKeyId
+     *
+     * @return $this
+     */
+    public function privateKeyId(?string $privateKeyId): self
+    {
+        $this->privateKeyId = $privateKeyId;
+
+        return $this;
+    }
+
+    /**
+     * @param string|null $privateKey
+     *
+     * @return $this
+     */
+    public function privateKey(?string $privateKey): self
+    {
+        $this->privateKey = $privateKey;
+
+        return $this;
+    }
+
+    /**
+     * @param bool $sandbox
+     *
+     * @return $this
+     */
+    public function sandbox(bool $sandbox): self
+    {
+        $this->sandbox = $sandbox;
+
+        return $this;
+    }
+
+    /**
+     * @return Client
+     */
+    protected function createClient(): Client
+    {
+        $baseURI = $this->sandbox ? ClientFactory::STORE_KIT_SANDBOX_URI : ClientFactory::STORE_KIT_PRODUCTION_URI;
+
+        return ClientFactory::create($this->sandbox, ['base_uri' => $baseURI]);
+    }
+}

--- a/tests/Doubles/AppStoreTestNotificationServiceBuilderDouble.php
+++ b/tests/Doubles/AppStoreTestNotificationServiceBuilderDouble.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Doubles;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Response;
+use Imdhemy\AppStore\ClientFactory;
+use Imdhemy\Purchases\Services\AppStoreTestNotificationServiceBuilder;
+use JsonException;
+
+class AppStoreTestNotificationServiceBuilderDouble extends AppStoreTestNotificationServiceBuilder
+{
+    public const PRODUCTION_TOKEN = 'production-token';
+    public const SANDBOX_TOKEN = 'sandbox-token';
+
+    /**
+     * @return Client
+     * @throws JsonException
+     */
+    protected function createClient(): Client
+    {
+        $token = $this->sandbox ? self::SANDBOX_TOKEN : self::PRODUCTION_TOKEN;
+
+        $body = json_encode(['testNotificationToken' => $token], JSON_THROW_ON_ERROR);
+
+        return ClientFactory::mock(new Response(200, [], $body));
+    }
+}

--- a/tests/Doubles/LiapTestProvider.php
+++ b/tests/Doubles/LiapTestProvider.php
@@ -5,8 +5,10 @@ namespace Tests\Doubles;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 use Imdhemy\Purchases\Console\LiapUrlCommand;
+use Imdhemy\Purchases\Console\RequestTestNotificationCommand;
 use Imdhemy\Purchases\Console\UrlGenerator;
 use Imdhemy\Purchases\Contracts\UrlGenerator as UrlGeneratorContract;
+use Imdhemy\Purchases\Services\AppStoreTestNotificationServiceBuilder;
 
 /**
  * Service provider for testing purposes
@@ -34,6 +36,15 @@ class LiapTestProvider extends ServiceProvider
             ->needs(UrlGeneratorContract::class)
             ->give(function (Application $app) {
                 $concrete = $app->runningUnitTests() ? UrlGeneratorDouble::class : UrlGenerator::class;
+
+                return $app->make($concrete);
+            });
+
+        $this->app->when(RequestTestNotificationCommand::class)
+            ->needs(AppStoreTestNotificationServiceBuilder::class)
+            ->give(function (Application $app) {
+                $concrete = $app->runningUnitTests() ?
+                    AppStoreTestNotificationServiceBuilderDouble::class : AppStoreTestNotificationServiceBuilder::class;
 
                 return $app->make($concrete);
             });

--- a/tests/Faker.php
+++ b/tests/Faker.php
@@ -15,6 +15,8 @@ use RuntimeException;
 /**
  * Class Faker
  * This class is a wrapper for the Faker library.
+ *
+ * @mixin Generator
  */
 class Faker
 {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -67,4 +67,34 @@ class TestCase extends Orchestra
 
         return $assetsPath;
     }
+
+    /**
+     * Generates a fake p8 key
+     */
+    protected function generateP8Key(): string
+    {
+        $key = 'MHQCAQEEIPKsJBiuilVdbtkxtPpSp0LLlUeqCmwx6Ss2OBvIhTbioAcGBSuBBAAK
+oUQDQgAEacH/sdtom9kl/0AvHFNNuoxnUWzLwWXf70qH2O1FDrvjDXY2aC7NFg9t
+WtcP+PnScROkjnSv6H6A6ekLVAzQYg==';
+
+        $filename = 'privateKey-' . time() . '.p8';
+        $path = $this->testAssetPath($filename);
+
+        if (! file_exists($path)) {
+            $contents = "-----BEGIN EC PRIVATE KEY-----\n" . $key . "\n-----END EC PRIVATE KEY-----";
+            file_put_contents($path, $contents);
+        }
+
+        return $path;
+    }
+
+    /**
+     * Deletes the given file is exists
+     */
+    protected function deleteFile(string $path): void
+    {
+        if (file_exists($path)) {
+            unlink($path);
+        }
+    }
 }

--- a/tests/Unit/Console/RequestTestNotificationCommandTest.php
+++ b/tests/Unit/Console/RequestTestNotificationCommandTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Console;
+
+use Symfony\Component\Console\Command\Command;
+use Tests\Doubles\AppStoreTestNotificationServiceBuilderDouble;
+use Tests\TestCase;
+
+class RequestTestNotificationCommandTest extends TestCase
+{
+    private string $privateKey;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->privateKey = $this->generateP8Key();
+    }
+
+    /**
+     * @test
+     */
+    public function it_validates_private_key_id_is_configured(): void
+    {
+        $this->artisan('liap:apple:test-notification')
+            ->expectsOutput('The private key ID is not configured')
+            ->assertExitCode(Command::FAILURE);
+    }
+
+    /**
+     * @test
+     */
+    public function it_validates_private_key_is_configured(): void
+    {
+        $this->app['config']->set('liap.appstore_private_key_id', 'private-key-id');
+
+        $this->artisan('liap:apple:test-notification')
+            ->expectsOutput('The private key is not configured')
+            ->assertExitCode(Command::FAILURE);
+    }
+
+    /**
+     * @test
+     */
+    public function it_validates_issuer_id_is_configured(): void
+    {
+        $this->app['config']->set('liap.appstore_private_key_id', 'private-key-id');
+        $this->app['config']->set('liap.appstore_private_key', $this->privateKey);
+
+        $this->artisan('liap:apple:test-notification')
+            ->expectsOutput('The issuer ID is not configured')
+            ->assertExitCode(Command::FAILURE);
+    }
+
+    /**
+     * @test
+     */
+    public function it_validates_bundle_id_is_configured(): void
+    {
+        $this->app['config']->set('liap.appstore_private_key_id', 'private-key-id');
+        $this->app['config']->set('liap.appstore_private_key', $this->privateKey);
+        $this->app['config']->set('liap.appstore_issuer_id', 'issuer-id');
+
+        $this->artisan('liap:apple:test-notification')
+            ->expectsOutput('The bundle ID is not configured')
+            ->assertExitCode(Command::FAILURE);
+    }
+
+    /**
+     * @test
+     */
+    public function it_requests_a_test_notification(): void
+    {
+        $this->app['config']->set('liap.appstore_private_key_id', 'private-key-id');
+        $this->app['config']->set('liap.appstore_private_key', $this->privateKey);
+        $this->app['config']->set('liap.appstore_issuer_id', 'issuer-id');
+        $this->app['config']->set('liap.appstore_bundle_id', 'bundle-id');
+
+        $this->artisan('liap:apple:test-notification')
+            ->expectsOutput(
+                sprintf("Test notification token: %s", AppStoreTestNotificationServiceBuilderDouble::PRODUCTION_TOKEN)
+            )
+            ->assertExitCode(Command::SUCCESS);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_request_a_test_notification_from_sandbox_server(): void
+    {
+        $this->app['config']->set('liap.appstore_private_key_id', 'private-key-id');
+        $this->app['config']->set('liap.appstore_private_key', $this->privateKey);
+        $this->app['config']->set('liap.appstore_issuer_id', 'issuer-id');
+        $this->app['config']->set('liap.appstore_bundle_id', 'bundle-id');
+
+        $this->artisan('liap:apple:test-notification --sandbox')
+            ->expectsOutput(
+                sprintf("Test notification token: %s", AppStoreTestNotificationServiceBuilderDouble::SANDBOX_TOKEN)
+            )
+            ->assertExitCode(Command::SUCCESS);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->deleteFile($this->privateKey);
+    }
+}

--- a/tests/Unit/Services/AppStoreTestNotificationServiceTest.php
+++ b/tests/Unit/Services/AppStoreTestNotificationServiceTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services;
+
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Psr7\Response;
+use Imdhemy\AppStore\ClientFactory;
+use Imdhemy\AppStore\Jws\JwsGenerator;
+use Imdhemy\AppStore\ServerNotifications\TestNotificationService;
+use Imdhemy\Purchases\Services\AppStoreTestNotificationService;
+use Tests\TestCase;
+
+class AppStoreTestNotificationServiceTest extends TestCase
+{
+    /**
+     * @test
+     * @throws GuzzleException
+     */
+    public function request(): void
+    {
+        $history = [];
+        $client = ClientFactory::mock(new Response(), $history);
+        $service = new TestNotificationService($client, $this->createMock(JwsGenerator::class));
+
+        $sut = new AppStoreTestNotificationService($service);
+
+        $sut->request();
+
+        $this->assertCount(1, $history);
+        $request = $history[0]['request'];
+        $this->assertEquals('POST', $request->getMethod());
+        $this->assertEquals('/inApps/v1/notifications/test', $request->getUri()->getPath());
+    }
+}


### PR DESCRIPTION
| Q             | A                                                                        |
|---------------|--------------------------------------------------------------------------|
| Branch?       |1.x  |
| Bug fix?      | no                                                                   |
| New feature?  | yes <!-- please update /CHANGELOG.md files -->                        |
| Deprecations? | no <!-- please update UPGRADE-*.md and /CHANGELOG.md files -->       |
| Tickets       | Fix #142  <!-- prefix each issue number with "Fix #", -->                 |
| License       | MIT                                                                      |

This PR adds a new service and a console command to request a test notification from Apple.

### Usage

**Update your** `/config/liap.php`

https://github.com/imdhemy/laravel-in-app-purchases/blob/11d2681eefc8cdffa674a67aa5b907a04c141b77/config/liap.php#L94-L101

**To request a test notification:**

```
php artisan liap:apple:test-notification
```

**To request a test notification from the sandbox server**

```
php artisan liap:apple:test-notification --sandbox
```

