### PR TITLE
Allow container to resolve command dependencies via handle()

### DIFF
--- a/src/Console/LiapUrlCommand.php
+++ b/src/Console/LiapUrlCommand.php
@@ -49,25 +49,18 @@ class LiapUrlCommand extends Command
     private Collection $urlCollection;
 
     /**
-     * @inheritDoc
+     * Execute the console command.
+     *
+     * @param  UrlGenerator  $urlGenerator
+     * @param  Collection  $urlCollection
+     * @return int
      */
-    public function __construct(UrlGenerator $urlGenerator, Collection $urlCollection)
+    public function handle(UrlGenerator $urlGenerator, Collection $urlCollection): int
     {
-        parent::__construct();
-
         $this->urlGenerator = $urlGenerator;
 
         $this->urlCollection = $urlCollection;
-    }
 
-
-    /**
-     * Execute the console command.
-     *
-     * @return int
-     */
-    public function handle(): int
-    {
         $this->generateUrls();
 
         $this->table(self::TABLE_HEADERS, $this->urlCollection->toArray());

--- a/src/Console/RequestTestNotificationCommand.php
+++ b/src/Console/RequestTestNotificationCommand.php
@@ -33,24 +33,16 @@ class RequestTestNotificationCommand extends Command
     private ServiceBuilder $serviceBuilder;
 
     /**
-     * @param ServiceBuilder $serviceBuilder
-     */
-    public function __construct(ServiceBuilder $serviceBuilder)
-    {
-        parent::__construct();
-
-        $this->serviceBuilder = $serviceBuilder;
-    }
-
-
-    /**
      * Execute the console command
      *
+     * @param  ServiceBuilder  $serviceBuilder
      * @return int
      * @throws JsonException
      */
-    public function handle(): int
+    public function handle(ServiceBuilder $serviceBuilder): int
     {
+        $this->serviceBuilder = $serviceBuilder;
+
         try {
             $response = $this->buildService()->request();
 

--- a/tests/Doubles/LiapTestProvider.php
+++ b/tests/Doubles/LiapTestProvider.php
@@ -2,7 +2,6 @@
 
 namespace Imdhemy\Purchases\Tests\Doubles;
 
-use Illuminate\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 use Imdhemy\Purchases\Contracts\UrlGenerator as UrlGeneratorContract;
 use Imdhemy\Purchases\Services\AppStoreTestNotificationServiceBuilder;
@@ -29,7 +28,11 @@ class LiapTestProvider extends ServiceProvider
      */
     public function register(): void
     {
-        $this->app->bind(UrlGeneratorContract::class, UrlGeneratorDouble::class);
+        $this->app->bind(
+            UrlGeneratorContract::class,
+            UrlGeneratorDouble::class
+        );
+
         $this->app->bind(
             AppStoreTestNotificationServiceBuilder::class,
             AppStoreTestNotificationServiceBuilderDouble::class

--- a/tests/Doubles/LiapTestProvider.php
+++ b/tests/Doubles/LiapTestProvider.php
@@ -4,9 +4,6 @@ namespace Imdhemy\Purchases\Tests\Doubles;
 
 use Illuminate\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
-use Imdhemy\Purchases\Console\LiapUrlCommand;
-use Imdhemy\Purchases\Console\RequestTestNotificationCommand;
-use Imdhemy\Purchases\Console\UrlGenerator;
 use Imdhemy\Purchases\Contracts\UrlGenerator as UrlGeneratorContract;
 use Imdhemy\Purchases\Services\AppStoreTestNotificationServiceBuilder;
 
@@ -32,21 +29,10 @@ class LiapTestProvider extends ServiceProvider
      */
     public function register(): void
     {
-        $this->app->when(LiapUrlCommand::class)
-            ->needs(UrlGeneratorContract::class)
-            ->give(function (Application $app) {
-                $concrete = $app->runningUnitTests() ? UrlGeneratorDouble::class : UrlGenerator::class;
-
-                return $app->make($concrete);
-            });
-
-        $this->app->when(RequestTestNotificationCommand::class)
-            ->needs(AppStoreTestNotificationServiceBuilder::class)
-            ->give(function (Application $app) {
-                $concrete = $app->runningUnitTests() ?
-                    AppStoreTestNotificationServiceBuilderDouble::class : AppStoreTestNotificationServiceBuilder::class;
-
-                return $app->make($concrete);
-            });
+        $this->app->bind(UrlGeneratorContract::class, UrlGeneratorDouble::class);
+        $this->app->bind(
+            AppStoreTestNotificationServiceBuilder::class,
+            AppStoreTestNotificationServiceBuilderDouble::class
+        );
     }
 }

--- a/tests/Handlers/AbstractNotificationHandlerTest.php
+++ b/tests/Handlers/AbstractNotificationHandlerTest.php
@@ -6,7 +6,7 @@ use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\Request;
 use Illuminate\Validation\Factory;
 use Illuminate\Validation\ValidationException;
-use Imdhemy\Purchases\Contracts\UrlGenerator;
+use Imdhemy\Purchases\Console\UrlGenerator;
 use Imdhemy\Purchases\Handlers\AbstractNotificationHandler;
 use Imdhemy\Purchases\Handlers\HandlerHelpers;
 use Imdhemy\Purchases\Tests\TestCase;


### PR DESCRIPTION
| Q             | A                                                                        |
|---------------|--------------------------------------------------------------------------|
| Branch?       | `master`|
| Bug fix?      | yes                                                                  |
| New feature?  | no |
| Deprecations? | no  |
| Tickets       | Fix #237 |
| License       | MIT                                                                      |

Removes `__construct()` calls (as they are fully inherited), adds typehints to `handle()` methods instead.