### PR TITLE
[1.x] Fetch google credentials file from the base path

### DIFF
--- a/config/liap.php
+++ b/config/liap.php
@@ -39,7 +39,7 @@ return [
      | @see https://imdhemy.com/laravel-iap-docs/docs/credentials/google-play
      |
      */
-    'google_application_credentials' => env('GOOGLE_APPLICATION_CREDENTIALS', null),
+    'google_application_credentials' => base_path(env('GOOGLE_APPLICATION_CREDENTIALS')),
 
     /*
      |--------------------------------------------------------------------------

--- a/src/ServiceProviders/LiapServiceProvider.php
+++ b/src/ServiceProviders/LiapServiceProvider.php
@@ -117,7 +117,8 @@ class LiapServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(self::CONFIG_PATH, self::CONFIG_KEY);
 
         $googleCredentials = config(self::CONFIG_KEY . '.google_application_credentials');
-        if ($googleCredentials !== null) {
+
+        if ($googleCredentials !== null && ! is_dir($googleCredentials)) {
             if (! file_exists($googleCredentials)) {
                 throw new RuntimeException("Google Application Credentials file not found at $googleCredentials");
             }


### PR DESCRIPTION
| Q             | A                                                                        |
|---------------|--------------------------------------------------------------------------|
| Branch?       | 1.x <!-- see below --> |
| Bug fix?      | yes                                                                 |
| New feature?  |no <!-- please update /CHANGELOG.md files -->                        |
| Deprecations? | no <!-- please update UPGRADE-*.md and /CHANGELOG.md files -->       |
| Tickets       | Fix #196, #260 <!-- prefix each issue number with "Fix #", -->                 |
| License       | MIT                                                                      |

This PR fixes an issue that has been reported many times. I found the suggestion from @rodrigolopespt in #196 would stop confusion about the path of the google credentials file.