### PR TITLE
[1.x] Get provider from server notification

### DIFF
--- a/src/Contracts/ServerNotificationContract.php
+++ b/src/Contracts/ServerNotificationContract.php
@@ -11,6 +11,9 @@ use GuzzleHttp\Client;
  */
 interface ServerNotificationContract
 {
+    public const PROVIDER_GOOGLE_PLAY = 'google_play';
+    public const PROVIDER_APP_STORE = 'app_store';
+
     /**
      * Gets the notification type.
      */
@@ -35,4 +38,9 @@ interface ServerNotificationContract
      * Gets the notification payload.
      */
     public function getPayload(): array;
+
+    /**
+     * Gets the notification provider.
+     */
+    public function getProvider(): string;
 }

--- a/src/ServerNotifications/AppStoreServerNotification.php
+++ b/src/ServerNotifications/AppStoreServerNotification.php
@@ -14,10 +14,7 @@ use Imdhemy\Purchases\ValueObjects\Time;
 
 class AppStoreServerNotification implements ServerNotificationContract
 {
-    /**
-     * @var ServerNotification
-     */
-    private $notification;
+    private ServerNotification $notification;
 
     /**
      * AppStoreServerNotification constructor.
@@ -78,5 +75,10 @@ class AppStoreServerNotification implements ServerNotificationContract
     public function getAutoRenewProductId(): ?string
     {
         return $this->notification->getAutoRenewProductId();
+    }
+
+    public function getProvider(): string
+    {
+        return self::PROVIDER_APP_STORE;
     }
 }

--- a/src/ServerNotifications/AppStoreV2ServerNotification.php
+++ b/src/ServerNotifications/AppStoreV2ServerNotification.php
@@ -68,4 +68,9 @@ class AppStoreV2ServerNotification implements ServerNotificationContract, HasSub
     {
         return (string)$this->payload->getSubType();
     }
+
+    public function getProvider(): string
+    {
+        return self::PROVIDER_APP_STORE;
+    }
 }

--- a/src/ServerNotifications/GoogleServerNotification.php
+++ b/src/ServerNotifications/GoogleServerNotification.php
@@ -62,4 +62,9 @@ class GoogleServerNotification implements ServerNotificationContract
     {
         return $this->notification->toArray();
     }
+
+    public function getProvider(): string
+    {
+        return self::PROVIDER_GOOGLE_PLAY;
+    }
 }

--- a/tests/ServerNotifications/AppStoreServerNotificationTest.php
+++ b/tests/ServerNotifications/AppStoreServerNotificationTest.php
@@ -94,4 +94,12 @@ class AppStoreServerNotificationTest extends TestCase
     {
         $this->assertNotNull($this->appStoreServerNotification->getAutoRenewProductId());
     }
+
+    /**
+     * @test
+     */
+    public function get_provider(): void
+    {
+        $this->assertEquals('app_store', $this->appStoreServerNotification->getProvider());
+    }
 }

--- a/tests/ServerNotifications/AppStoreV2ServerNotificationTest.php
+++ b/tests/ServerNotifications/AppStoreV2ServerNotificationTest.php
@@ -84,4 +84,12 @@ class AppStoreV2ServerNotificationTest extends TestCase
     {
         $this->assertEquals(V2DecodedPayload::SUBTYPE_INITIAL_BUY, $this->sut->getSubtype());
     }
+
+    /**
+     * @test
+     */
+    public function get_provider(): void
+    {
+        $this->assertEquals('app_store', $this->sut->getProvider());
+    }
 }

--- a/tests/ServerNotifications/GoogleServerNotificationTest.php
+++ b/tests/ServerNotifications/GoogleServerNotificationTest.php
@@ -70,4 +70,12 @@ class GoogleServerNotificationTest extends TestCase
     {
         $this->assertEquals($this->developerNotification->toArray(), $this->googleServerNotification->getPayload());
     }
+
+    /**
+     * @test
+     */
+    public function get_provider(): void
+    {
+        $this->assertEquals('google_play', $this->googleServerNotification->getProvider());
+    }
 }


### PR DESCRIPTION
| Q             | A                                                                        |
|---------------|--------------------------------------------------------------------------|
| Branch?       | 1.x |
| Bug fix?      | no                                                                  |
| New feature?  | yes <!-- please update /CHANGELOG.md files -->                        |
| Deprecations? | no <!-- please update UPGRADE-*.md and /CHANGELOG.md files -->       |
| Tickets       | #266  <!-- prefix each issue number with "Fix #", -->                 |
| License       | MIT                                                                      |

This PR adds a new getter method to server notifications to get the notification provider.
