### PR TITLE
[google-play] support product consume

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "ext-json": "*",
     "ext-openssl": "*",
     "imdhemy/appstore-iap": "^1.6",
-    "imdhemy/google-play-billing": "^1.4",
+    "imdhemy/google-play-billing": "^1.5",
     "laravel/framework": ">=8.0"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fe1abfc817463eb99c7c21362e895306",
+    "content-hash": "8733cc5c2a607e8391b8a821bce0cbcb",
     "packages": [
         {
             "name": "brick/math",
@@ -995,16 +995,16 @@
         },
         {
             "name": "imdhemy/google-play-billing",
-            "version": "1.4.2",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/imdhemy/google-play-billing.git",
-                "reference": "d318db28efafb56ac8954c9f651fbe6ac367d637"
+                "reference": "a227174a71bc5d7b3e5f9aa4fcad2c4a9a11a8a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/imdhemy/google-play-billing/zipball/d318db28efafb56ac8954c9f651fbe6ac367d637",
-                "reference": "d318db28efafb56ac8954c9f651fbe6ac367d637",
+                "url": "https://api.github.com/repos/imdhemy/google-play-billing/zipball/a227174a71bc5d7b3e5f9aa4fcad2c4a9a11a8a4",
+                "reference": "a227174a71bc5d7b3e5f9aa4fcad2c4a9a11a8a4",
                 "shasum": ""
             },
             "require": {
@@ -1040,9 +1040,9 @@
             "description": "Google Play Billing",
             "support": {
                 "issues": "https://github.com/imdhemy/google-play-billing/issues",
-                "source": "https://github.com/imdhemy/google-play-billing/tree/1.4.2"
+                "source": "https://github.com/imdhemy/google-play-billing/tree/1.5.0"
             },
-            "time": "2023-07-04T16:00:39+00:00"
+            "time": "2023-09-17T12:33:33+00:00"
         },
         {
             "name": "laravel/framework",

--- a/src/Product.php
+++ b/src/Product.php
@@ -99,9 +99,6 @@ class Product
     /**
      * @throws GuzzleException
      */
-    /**
-     * byme
-     */
     public function consume(): EmptyResponse
     {
         return $this->createProduct()->consume();

--- a/src/Product.php
+++ b/src/Product.php
@@ -97,6 +97,17 @@ class Product
     }
 
     /**
+     * @throws GuzzleException
+     */
+    /**
+     * byme
+     */
+    public function consume(): EmptyResponse
+    {
+        return $this->createProduct()->consume();
+    }
+
+    /**
      * @throws GuzzleException|InvalidReceiptException
      */
     public function verifyReceipt(): ReceiptResponse


### PR DESCRIPTION
New feature:
Add consume to google billing for consomable item

how to use it : 
$consumeitemGoogle = Product::googlePlay()->id($itemId)->token($purchaseToken)->consume();

Need change on repo laravel-in-app-purchases and google-play-billing