### PR TITLE
[1.x] fix: remove GOOGLE_APPLICATION_CREDENTIALS env

### DIFF
--- a/config/liap.php
+++ b/config/liap.php
@@ -31,18 +31,7 @@ return [
      |
      */
     'google_play_package_name' => env('GOOGLE_PLAY_PACKAGE_NAME', 'com.some.thing'),
-
-    /*
-     |--------------------------------------------------------------------------
-     | Google Application Credentials
-     |--------------------------------------------------------------------------
-     |
-     | This value is the path to the Google Application Credentials file.
-     | @see https://imdhemy.com/laravel-iap-docs/docs/credentials/google-play
-     |
-     */
-    'google_application_credentials' => base_path((string)env('GOOGLE_APPLICATION_CREDENTIALS')),
-
+    
     /*
      |--------------------------------------------------------------------------
      | App Store Password

--- a/config/liap.php
+++ b/config/liap.php
@@ -31,7 +31,7 @@ return [
      |
      */
     'google_play_package_name' => env('GOOGLE_PLAY_PACKAGE_NAME', 'com.some.thing'),
-    
+
     /*
      |--------------------------------------------------------------------------
      | App Store Password

--- a/src/ServiceProviders/LiapServiceProvider.php
+++ b/src/ServiceProviders/LiapServiceProvider.php
@@ -112,12 +112,6 @@ class LiapServiceProvider extends ServiceProvider
     private function registerConfig(): void
     {
         $this->mergeConfigFrom(self::CONFIG_PATH, self::CONFIG_KEY);
-
-        $googleApplicationCredentials = (string)config('liap.google_application_credentials');
-
-        if (! empty($googleApplicationCredentials) && file_exists($googleApplicationCredentials)) {
-            putenv("GOOGLE_APPLICATION_CREDENTIALS=$googleApplicationCredentials");
-        }
     }
 
     /**


### PR DESCRIPTION
| Q             | A                                                                |
|---------------|------------------------------------------------------------------|
| Branch?       | 1.x <!-- see below -->                                           |
| Deprecations? | no <!-- please update UPGRADE-2.0.md and /CHANGELOG.md files --> |
| Tickets       | Fix #430  <!-- prefix each issue number with "Fix #", -->        |
| License       | MIT                                                              |

Many developers faced issues with setting the Google Play credentials in the environment variable.
It would be easier to depend on The well-known path which is an OS-dependent method to get the credentials.

Ref: https://github.com/googleapis/google-auth-library-php/blob/1601efc2f1f362437beda2c4212f1f471568dee6/src/CredentialsLoader.php#L97

This is also documented https://imdhemy.com/laravel-iap-docs/docs/credentials/google-play#setting-the-credentials
