### PR TITLE
[1.x] Dispatch event on incoming notifications

### DIFF
--- a/src/Events/NotificationReceived.php
+++ b/src/Events/NotificationReceived.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Imdhemy\Purchases\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class NotificationReceived
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    /**
+     * The notification payload.
+     *
+     * @var array
+     */
+    public $payload;
+
+    /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct(array $payload)
+    {
+        $this->payload = $payload;
+    }
+}

--- a/src/Handlers/AbstractNotificationHandler.php
+++ b/src/Handlers/AbstractNotificationHandler.php
@@ -11,6 +11,7 @@ use Illuminate\Validation\ValidationException;
 use Imdhemy\Purchases\Contracts\EventFactory;
 use Imdhemy\Purchases\Contracts\NotificationHandlerContract;
 use Imdhemy\Purchases\Contracts\UrlGenerator;
+use Imdhemy\Purchases\Events\NotificationReceived;
 
 abstract class AbstractNotificationHandler implements NotificationHandlerContract
 {
@@ -40,6 +41,10 @@ abstract class AbstractNotificationHandler implements NotificationHandlerContrac
         $this->authorize();
 
         $this->validate();
+
+        NotificationReceived::dispatch(
+            json_decode($this->request->getContent(), true)
+        );
 
         $this->handle();
     }

--- a/src/Handlers/AbstractNotificationHandler.php
+++ b/src/Handlers/AbstractNotificationHandler.php
@@ -42,9 +42,10 @@ abstract class AbstractNotificationHandler implements NotificationHandlerContrac
 
         $this->validate();
 
-        NotificationReceived::dispatch(
-            json_decode($this->request->getContent(), true)
-        );
+        $requestContent = (string)$this->request->getContent();
+        if ('' !== trim($requestContent)) {
+            NotificationReceived::dispatch(json_decode($requestContent, true));
+        }
 
         $this->handle();
     }

--- a/src/Handlers/AbstractNotificationHandler.php
+++ b/src/Handlers/AbstractNotificationHandler.php
@@ -42,10 +42,7 @@ abstract class AbstractNotificationHandler implements NotificationHandlerContrac
 
         $this->validate();
 
-        $requestContent = (string)$this->request->getContent();
-        if ('' !== trim($requestContent)) {
-            NotificationReceived::dispatch(json_decode($requestContent, true));
-        }
+        $this->dispatchEvent();
 
         $this->handle();
     }
@@ -69,6 +66,17 @@ abstract class AbstractNotificationHandler implements NotificationHandlerContrac
         }
 
         return $this->urlGenerator->hasValidSignature($this->request);
+    }
+
+    protected function dispatchEvent(): void
+    {
+        $requestContent = (string)$this->request->getContent();
+
+        if ('' !== trim($requestContent)) {
+            $payload = (array)json_decode($requestContent, true);
+            $event = new NotificationReceived($payload);
+            event($event);
+        }
     }
 
     /**

--- a/tests/Http/Controllers/ServerNotificationControllerTest.php
+++ b/tests/Http/Controllers/ServerNotificationControllerTest.php
@@ -9,6 +9,7 @@ use Imdhemy\AppStore\Jws\JwsVerifier;
 use Imdhemy\Purchases\Events\AppStore\DidChangeRenewalStatus;
 use Imdhemy\Purchases\Events\AppStore\Subscribed;
 use Imdhemy\Purchases\Events\GooglePlay\SubscriptionRecovered;
+use Imdhemy\Purchases\Events\NotificationReceived;
 use Imdhemy\Purchases\Tests\TestCase;
 use JsonException;
 
@@ -36,8 +37,9 @@ class ServerNotificationControllerTest extends TestCase
 
         $uri = url('/liap/notifications?provider=google-play');
 
-        $this->post($uri, $data)->assertStatus(200);
+        $this->postJson($uri, $data)->assertStatus(200);
 
+        Event::assertDispatched(NotificationReceived::class);
         Event::assertDispatched(SubscriptionRecovered::class);
     }
 
@@ -55,7 +57,7 @@ class ServerNotificationControllerTest extends TestCase
         ];
 
         $uri = url('/liap/notifications?provider=google-play');
-        $this->post($uri, $data)->assertStatus(200);
+        $this->postJson($uri, $data)->assertStatus(200);
 
         $this->assertNotEmpty(
             file_get_contents(storage_path('/logs/laravel.log'))
@@ -81,8 +83,9 @@ class ServerNotificationControllerTest extends TestCase
             JSON_THROW_ON_ERROR
         );
         $uri = url('/liap/notifications?provider=app-store');
-        $this->post($uri, $data)->assertStatus(200);
+        $this->postJson($uri, $data)->assertStatus(200);
 
+        Event::assertDispatched(NotificationReceived::class);
         Event::assertDispatched(DidChangeRenewalStatus::class);
     }
 
@@ -102,7 +105,7 @@ class ServerNotificationControllerTest extends TestCase
             JSON_THROW_ON_ERROR
         );
         $uri = url('/liap/notifications?provider=google-play');
-        $this->post($uri, $data)->assertStatus(200);
+        $this->postJson($uri, $data)->assertStatus(200);
 
         $this->assertNotEmpty(
             file_get_contents(storage_path('/logs/laravel.log'))
@@ -120,7 +123,7 @@ class ServerNotificationControllerTest extends TestCase
         $signedPayload = $this->faker->appStoreTestNotification();
         $uri = url('/liap/notifications?provider=app-store');
 
-        $this->post($uri, ['signedPayload' => $signedPayload->toString()])->assertStatus(200);
+        $this->postJson($uri, ['signedPayload' => $signedPayload->toString()])->assertStatus(200);
 
         $logs = file_get_contents(storage_path('/logs/laravel.log'));
         $this->assertStringContainsString('AppStoreV2NotificationHandler: Test notification received', $logs);
@@ -136,8 +139,9 @@ class ServerNotificationControllerTest extends TestCase
         $signedPayload = $this->faker->appStoreNotification();
         $uri = url('/liap/notifications?provider=app-store');
 
-        $this->post($uri, ['signedPayload' => $signedPayload->toString()])->assertStatus(200);
+        $this->postJson($uri, ['signedPayload' => $signedPayload->toString()])->assertStatus(200);
 
+        Event::assertDispatched(NotificationReceived::class);
         Event::assertDispatched(Subscribed::class);
     }
 }


### PR DESCRIPTION
| Q             | A                                                                    |
|---------------|----------------------------------------------------------------------|
| Branch?       | 1.x                                |
| Deprecations? | no |
| Tickets       | -             |
| License       | MIT                                                                  |

A relatively simple but useful addition to this library. This allows for an easy way to develop a custom implementation, in addition to the standard handling of server notifications, by capturing this special notification received event. This implementation is very similar to the way Laravel Cashier handles [webhooks](https://laravel.com/docs/11.x/billing#defining-webhook-event-handlers).
