### PR TITLE
Add docstring to FallbackEvent class for improved documentation

### DIFF
--- a/src/Events/FallbackEvent.php
+++ b/src/Events/FallbackEvent.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 namespace Imdhemy\Purchases\Events;
 
+/**
+ * Represents a fallback event for in-app purchases.
+ *
+ * This class extends PurchaseEvent to handle cases where a specific event type is not recognized,
+ * acting as a default or fallback event in purchase event handling.
+ */
 final class FallbackEvent extends PurchaseEvent
 {
 }


### PR DESCRIPTION
## 问题背景

开源项目中，清晰的文档至关重要。`FallbackEvent` 类缺乏docstring，降低了代码的可读性和维护性，可能让贡献者和用户难以理解其用途，尤其在处理购买事件回退时。

## 修改内容

- 为 `FallbackEvent` 类添加了一个详细的docstring，解释它作为购买事件处理中默认或回退事件的作用。
- 遵循仓库的现有代码风格，确保文档简洁明了。

## 验证方式

- 通过手动代码审查，确认文档准确描述类的功能。
- 确保更改不改变类的公共API或行为，保持向后兼容性。
- 可参考其他事件类的文档进行一致性检查。